### PR TITLE
Zapier triggers

### DIFF
--- a/OWMZapier/authentication.js
+++ b/OWMZapier/authentication.js
@@ -1,0 +1,29 @@
+module.exports = {
+    type: 'custom', // Using custom authentication
+    fields: [
+      {
+        key: 'apiKey',
+        label: 'API Key',
+        required: true,
+        type: 'string',
+        helpText: 'Enter your OpenWeatherMap API key here.',
+      },
+    ],
+    test: async (z, bundle) => {
+      const response = await z.request({
+        url: 'https://api.openweathermap.org/data/2.5/weather',
+        params: {
+          q: 'London', // Example city to test the API key
+          appid: bundle.authData.apiKey, // Use the user's API key
+        },
+      });
+  
+      if (response.status !== 200) {
+        throw new Error('Invalid API Key. Please check your key and try again.');
+      }
+  
+      // Return some user-friendly data for the test
+      return response.json;
+    },
+  };
+  

--- a/OWMZapier/index.js
+++ b/OWMZapier/index.js
@@ -1,11 +1,15 @@
+const getCurrentWeather = require("./triggers/current_weather");
 module.exports = {
   // This is just shorthand to reference the installed dependencies you have.
   // Zapier will need to know these before we can upload.
   version: require('./package.json').version,
   platformVersion: require('zapier-platform-core').version,
+  authentication: require('./authentication'),
 
   // If you want your trigger to show up, you better include it here!
-  triggers: {},
+  triggers: {
+    [getCurrentWeather.key]: getCurrentWeather
+  },
 
   // If you want your searches to show up, you better include it here!
   searches: {},

--- a/OWMZapier/package-lock.json
+++ b/OWMZapier/package-lock.json
@@ -8,6 +8,7 @@
       "name": "OWMZapier",
       "version": "1.0.0",
       "dependencies": {
+        "dotenv": "^16.4.7",
         "zapier-platform-core": "16.1.1"
       },
       "devDependencies": {
@@ -1632,9 +1633,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.6",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
-      "integrity": "sha512-JhcR/+KIjkkjiU8yEpaB/USlzVi3i5whwOjpIRNGi9svKEXZSe+Qp6IWAjFjv+2GViAoDRCUv/QLNziQxsLqDg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -3990,6 +3991,18 @@
       "optional": true,
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/zapier-platform-core/node_modules/dotenv": {
+      "version": "16.4.6",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
+      "integrity": "sha512-JhcR/+KIjkkjiU8yEpaB/USlzVi3i5whwOjpIRNGi9svKEXZSe+Qp6IWAjFjv+2GViAoDRCUv/QLNziQxsLqDg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/zapier-platform-core/node_modules/semver": {

--- a/OWMZapier/package.json
+++ b/OWMZapier/package.json
@@ -7,6 +7,7 @@
     "test": "jest --testTimeout 10000"
   },
   "dependencies": {
+    "dotenv": "^16.4.7",
     "zapier-platform-core": "16.1.1"
   },
   "devDependencies": {

--- a/OWMZapier/test/triggers/current_weather.test.js
+++ b/OWMZapier/test/triggers/current_weather.test.js
@@ -1,0 +1,27 @@
+require('dotenv').config();
+const zapier = require('zapier-platform-core');
+
+// Use this to make test calls into your app:
+const App = require('../../index');
+const appTester = zapier.createAppTester(App);
+// read the `.env` file into the environment, if available
+zapier.tools.env.inject();
+
+describe('triggers.current_weather', () => {
+  it('should run', async () => {
+    const bundle = { 
+      authData: {
+        apiKey: process.env.OPENWEATHERMAP_API_KEY, // Use the environment variable
+      },
+      inputData: {
+        city: 'Dublin', // Replace with a city name for testing
+      } };
+
+    const results = await appTester(App.triggers['current_weather'].operation.perform, bundle);
+    expect(results).toBeDefined();
+    // TODO: add more assertions
+    expect(results.length).toBeGreaterThan(0); // Check that we get an array
+    expect(results[0]).toHaveProperty('id'); // Ensure each item has an ID
+    expect(results[0].name).toBe('Dublin'); // Validate city name
+  });
+});

--- a/OWMZapier/triggers/current_weather.js
+++ b/OWMZapier/triggers/current_weather.js
@@ -1,0 +1,69 @@
+// triggers on a new current_weather with a certain tag
+const getWeather = async (z, bundle) => {
+  const response = await z.request({
+    url: 'https://api.openweathermap.org/data/2.5/weather',
+    params: {
+      q: bundle.inputData.city,
+      appid: bundle.authData.apiKey,
+    }
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to fetch weather data: ${response.status}`);
+  }
+  // this should return an array of objects
+  // Convert response to an array and add an `id` property
+  const data = response.json;
+  return [
+    {
+      id: `${data.coord.lat},${data.coord.lon}`, // Unique ID for Zapier
+      ...data, // Spread all original fields
+    },
+  ];
+};
+
+module.exports = {
+  // see here for a full list of available properties:
+  // https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#triggerschema
+  key: 'current_weather',
+  noun: 'Current Weather',
+
+  display: {
+    label: 'Get Current Weather',
+    description: 'Triggers when weather data for a specific city is fetched'
+  },
+
+  operation: {
+    perform: getWeather,
+
+    // `inputFields` defines the fields a user could provide
+    // Zapier will pass them in as `bundle.inputData` later. They're optional.
+    inputFields: [
+      {
+        key: 'city',
+        label: 'City',
+        required: true,
+        type: 'string',
+        helpText: 'Enter the name of the city for which to fetch weather data',
+      },
+    ],
+
+    // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example
+    // from the API, Zapier will fallback to this hard-coded sample. It should reflect the data structure of
+    // returned records, and have obvious placeholder values that we can show to any user.
+    sample: {
+      id: 1,
+      name: 'Test'
+    },
+
+    // If fields are custom to each user (like spreadsheet columns), `outputFields` can create human labels
+    // For a more complete example of using dynamic fields see
+    // https://github.com/zapier/zapier-platform/tree/main/packages/cli#customdynamic-fields
+    // Alternatively, a static field definition can be provided, to specify labels for the fields
+    outputFields: [
+      // these are placeholders to match the example `perform` above
+      // {key: 'id', label: 'Person ID'},
+      // {key: 'name', label: 'Person Name'}
+    ]
+  }
+};


### PR DESCRIPTION
This PR adds triggers to my weather zapier app and introduces OpenWeatherMap's API key. I've added local tests that pass. I haven't pushed to Zapier yet.

- Custom Authentication:
Added `authentication.js` to handle API key-based authentication.
Verifies the validity of the user's OpenWeatherMap API key by making a test request to the API.

- New Trigger:
Added `current_weather.js` under the triggers folder to fetch current weather data for a specified city.
Configured input fields to accept the city name.
Returns structured data with a unique id and other weather details.

- Tests:
Added `current_weather.test.js` to test the trigger with a valid API key and city name.
Ensures the response is valid and contains expected properties like id and name.

- Updated Files:
`index.js`: Registered the current_weather trigger and added authentication integration.
`package.json` and `package-lock.json`: Added dotenv dependency for managing environment variables in tests.
